### PR TITLE
Use simplecov instead of rcov

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rspec'
 require 'rspec/core/rake_task'
 require 'rubygems/package_task'
 
-task :default => :spec
+
 
 desc "Run all specs in spec directory"
 RSpec::Core::RakeTask.new(:spec) do |t|
@@ -11,12 +11,11 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/**/*_spec.rb'
 end
 
-desc "Run all specs and generate RCov report"
-RSpec::Core::RakeTask.new('cov') do |t|
-  t.pattern = 'spec/**/*.rb'
-  t.rspec_opts = ["--colour"]
-  t.rcov = true
-  t.rcov_opts = ['-T --no-html --exclude', 'spec\/,gems\/']
+desc "Run all specs and generate simplecov report"
+task :cov do |t|
+  ENV['COVERAGE'] = 'true'
+  Rake::Task["spec"].execute
+  `open coverage/index.html`
 end
 
 spec = eval(File.read("discogs.gemspec"))

--- a/discogs.gemspec
+++ b/discogs.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   
   s.add_development_dependency "rspec", "= 2.12.0"
+  s.add_development_dependency "simplecov", "= 0.7.1"
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+if ENV["COVERAGE"]
+  require 'simplecov'
+  SimpleCov.start 
+end
 require 'rubygems'
 require 'rspec'
 require File.dirname(__FILE__) + '/../lib/discogs'


### PR DESCRIPTION
I work with ruby 1.9.3. rcov isn't supported by ruby 1.9. So I remplace it with simplecov. Rake task is the same (rake cov) but instead of printing the result in terminal, it's open a webpage with result.

Problem, simplecov doesn't work with ruby 1.8... But ruby 1.8 is end of life in June 2013.

2 solutions, just advice people to use ruby 1.9, or add some test in code to use rcov for ruby 1.8. and simplecov with ruby 1.9

This pull request use only simplecov, just tell me if you want support rcov !

We just talk about generation of a code coverage report. The rest of gem work fine under 1.8 and 1.9
