### PR TITLE
query string should be escaped

### DIFF
--- a/lib/wrapper/wrapper.rb
+++ b/lib/wrapper/wrapper.rb
@@ -68,7 +68,7 @@ class Discogs::Wrapper
     rescue Zlib::GzipFile::Error
         response_body = response.body
     end
-    
+
     response_body
   end
 
@@ -90,7 +90,7 @@ class Discogs::Wrapper
     parameters = { :f => "xml" }.merge(params)
     querystring = "?" + parameters.map { |key, value| "#{key}=#{value}" }.sort.join("&")
 
-    URI.parse(File.join(@@root_host, sanitize_path(path, querystring)))
+    URI.parse(File.join(@@root_host, sanitize_path(path, URI.escape(querystring))))
   end
 
   def sanitize_path(*path_parts)


### PR DESCRIPTION
Escaping of the query-string has been added.
URI::InvalidURIError: bad URI(is not URI?): http://api.discogs.com/search?f=xml&page=1&q=Stories+Don’t+End&type=all
