### PR TITLE
Encodes search URIs once, and only once.

### DIFF
--- a/lib/wrapper/wrapper.rb
+++ b/lib/wrapper/wrapper.rb
@@ -769,7 +769,7 @@ class Discogs::Wrapper
     parameters    = {:f => output_format}.merge(params)
     querystring   = "?" + URI.encode_www_form(prepare_hash(parameters))
 
-    URI.parse(File.join(@@root_host, URI.encode(sanitize_path(path, URI.escape(querystring)))))
+    URI.parse(File.join(@@root_host, [URI.escape(path), querystring].join))
   end
 
   # Stringifies keys and sorts.
@@ -781,11 +781,6 @@ class Discogs::Wrapper
     end
 
     result.sort
-  end
-
-  def sanitize_path(*path_parts)
-    clean_path = path_parts.map { |part| part.gsub(/\s/, '+') }
-    clean_path.join
   end
 
   def raise_unknown_resource(path="")

--- a/spec/wrapper_methods/search_spec.rb
+++ b/spec/wrapper_methods/search_spec.rb
@@ -8,6 +8,30 @@ describe Discogs::Wrapper do
     @search_type = "release"
   end
 
+  describe "when handling an advanced search" do
+
+    it "should properly encode the request URI" do
+      encoded_uri = "/database/search?f=json&q=Release+Title+artist%3AArtist+Name&type=release"
+      get = Net::HTTP::Get.new(encoded_uri)
+      Net::HTTP::Get.should_receive(:new).with(encoded_uri).and_return(get)
+
+      @wrapper.search("Release Title artist:Artist Name", :type => @search_type)
+    end
+
+  end
+
+  describe "when handling a search including whitespace" do
+
+    it "should properly encode spaces in the request URI" do
+      encoded_uri = "/database/search?f=json&q=One+Two"
+      get = Net::HTTP::Get.new(encoded_uri)
+      Net::HTTP::Get.should_receive(:new).with(encoded_uri).and_return(get)
+
+      @wrapper.search("One Two")
+    end
+
+  end
+
   describe "when asking for search result information" do
 
     before do


### PR DESCRIPTION
Previous code was escaping pieces of the URI multiple times, so when an
advanced search was performed, e.g. "Release Title artist:Artist Name",
the URI would be encoded as "Release+Title+artist%25253AArtist+Name"
instead of the expected "Release+Title%3AArtist+Name"
