### PR TITLE
Remove Hashie version in gemspec

### DIFF
--- a/discogs.gemspec
+++ b/discogs.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "= 2.12.0"
   s.add_development_dependency "simplecov", "= 0.7.1"
   
-  s.add_runtime_dependency "hashie", "~> 2.1"
+  s.add_runtime_dependency "hashie"
   s.add_runtime_dependency "oauth", "~> 0.4.7"
 
 end


### PR DESCRIPTION
We have conflicting version on the hashie gem... And we cannot use Discogs within our app because of that. Is it possible to remove the fixed version from the gemspec ? Or update it ?
