### PR TITLE
Replaces 'type_' attribute key with 'type', and ensures that #sanitize_hash is called on arrays of hashes.

### DIFF
--- a/lib/wrapper/wrapper.rb
+++ b/lib/wrapper/wrapper.rb
@@ -813,7 +813,7 @@ class Discogs::Wrapper
 
   # Replaces known conflicting keys with safe names in a nested hash structure.
   def sanitize_hash(hash)
-    conflicts = {"count" => "total"}
+    conflicts = {"count" => "total", "type_" => "type"}
     result = {}
 
     for k, v in hash
@@ -833,6 +833,8 @@ class Discogs::Wrapper
 
       if v.is_a?(Hash)
         result[k] = sanitize_hash(result[k])
+      elsif v.is_a?(Array)
+        result[k] = v.map { |o| o.is_a?(Hash) ? sanitize_hash(o) : o }
       end
     end
 


### PR DESCRIPTION
This is a fix to issues #53 and #58.

I'm not all that proud of the code that iterates through the array, and based on your code style I wouldn't be surprised if you wanted to rewrite it. But it does seem to do the job.

I see that in #58, the suggestion was to replace 'type_' with 'kind', but it seems that replacing it simply with 'type' works.

I've run the tests and they pass.