### PR TITLE
URI.escape obsolete, use CGI.escape

### DIFF
--- a/lib/wrapper/wrapper.rb
+++ b/lib/wrapper/wrapper.rb
@@ -797,7 +797,7 @@ class Discogs::Wrapper
     parameters    = {:f => output_format}.merge(params)
     querystring   = "?" + URI.encode_www_form(prepare_hash(parameters))
 
-    URI.parse(File.join(@@root_host, [URI.escape(path), querystring].join))
+    URI.parse(File.join(@@root_host, [CGI.escape(path), querystring].join))
   end
 
   # Stringifies keys and sorts.


### PR DESCRIPTION
The wrapper issues warnings with URI.escape, as the function is
obsolete ([see here](https://ruby-doc.org/stdlib-2.4.1/libdoc/uri/rdoc/URI/Escape.html)). CGI.escape should be used instead.

This project doesn't seem to be actively maintained anymore, but since this is the one on RubyGems and it's a very small change, I figured I'd open a PR anyway.