### PR TITLE
fix(Authentication): Add Namespace

### DIFF
--- a/discogs.gemspec
+++ b/discogs.gemspec
@@ -1,28 +1,22 @@
 Gem::Specification.new do |s|
-  
   s.name = "discogs-wrapper"
-  s.version = "2.5.1"
+  s.version = "2.6.0"
   s.date = "2020-05-10"
   s.licenses = ["MIT"]
   s.summary = "Discogs::Wrapper is a full wrapper for the http://www.discogs.com API V2"
   s.homepage = "https://www.github.com/buntine/discogs"
   s.email = "info@bunts.io"
   s.authors = ["Andrew Buntine", "Many more contributors - see https://github.com/buntine/discogs/graphs/contributors"]
-  
   s.description = "Discogs::Wrapper is a full wrapper for the http://www.discogs.com API V2. Supports authentication, pagination, JSON."
-  
   s.files = Dir.glob("{lib}/**/*") + %w(LICENSE README.markdown)
-
   s.test_files = Dir.glob("{spec}/**/*")
-
   s.platform = Gem::Platform::RUBY
-  
+
   s.add_development_dependency "pry", "~> 0"
   s.add_development_dependency "rspec", "~> 3.3"
   s.add_development_dependency "simplecov", "= 0.7.1"
-  
+
   s.add_runtime_dependency "hashie", "~> 3.0"
   s.add_runtime_dependency "httparty", "~> 0.14"
   s.add_runtime_dependency "oauth", "~> 0.5.1"
-
 end

--- a/lib/discogs.rb
+++ b/lib/discogs.rb
@@ -18,4 +18,4 @@ class Discogs::AuthenticationError < StandardError; end
 class Discogs::RateLimitError < StandardError; end
 
 # Loading sequence.
-require File.dirname(__FILE__) + "/wrapper/wrapper"
+require File.dirname(__FILE__) + "/discogs/wrapper"

--- a/lib/discogs/authentication.rb
+++ b/lib/discogs/authentication.rb
@@ -1,6 +1,6 @@
 require 'oauth'
 
-module Authentication
+module Discogs::Authentication
 
   def auth_params
     if self_authenticating?

--- a/lib/discogs/wrapper.rb
+++ b/lib/discogs/wrapper.rb
@@ -11,8 +11,7 @@ require 'zlib'
 require File.dirname(__FILE__) + "/authentication"
 
 class Discogs::Wrapper
-
-  include Authentication
+  include Discogs::Authentication
 
   @@root_host = "https://api.discogs.com"
 


### PR DESCRIPTION
## First
Hey there!! I realize it's been a while since this project had any work done so I'm not expecting a quick turn around on merging this 😬😂. But, I'm here looking to make use of it again! AFAICT everything still works besides one little hiccup I had installing the gem. Thanks for all the work here!

## Why this was needed
Now that Rails has it's own `Authentication` class, the `Authentication` class provided by this gem collides with it and overrides needed methods.

## How I fixed it
Renamed the `wrapper` folder to `discogs` and nested the `Authentication` class inside the `Discogs` module.