### PR TITLE
Drop verbose warnings about key renamings

### DIFF
--- a/lib/discogs/wrapper.rb
+++ b/lib/discogs/wrapper.rb
@@ -820,11 +820,6 @@ class Discogs::Wrapper
       safe_name = conflicts[k]
 
       if safe_name
-        # BC: Temporary set original key for backwards-compatibility.
-        warn "[DEPRECATED]: The key '#{k}' has been replaced with '#{safe_name}'. When accessing, please use the latter. This message will be removed in the next major release."
-        result[k] = v
-        # End BC
-
         result[safe_name] = v
         k = safe_name
       else


### PR DESCRIPTION
This actually drops TWO warnings:

- The warning we were printing
- The warning from Mashie generated because we were propogating the bad keynames

This will address #53

Signed-off-by: Phil Dibowitz <phil@ipom.com>
