### PR TITLE
Fix error raising

### DIFF
--- a/lib/discogs.rb
+++ b/lib/discogs.rb
@@ -16,6 +16,7 @@ class Discogs::UnknownResource < StandardError; end
 class Discogs::InternalServerError < StandardError; end
 class Discogs::AuthenticationError < StandardError; end
 class Discogs::RateLimitError < StandardError; end
+class Discogs::UnknownServerError < StandardError; end
 
 # Loading sequence.
 require File.dirname(__FILE__) + "/discogs/wrapper"


### PR DESCRIPTION
Currently if you get a 429 (or any other we theoretically catch), we
won't catch it because we're doing string comparisons on integers, and
thus we jsut get a JSON::ParserError.

This fixes that so we get the expected error classes.

In addition it adds a new unknown exception that gives the use some
extra information.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
